### PR TITLE
Print pages on render

### DIFF
--- a/cockpitdecks/decks/loupedeck.py
+++ b/cockpitdecks/decks/loupedeck.py
@@ -480,9 +480,18 @@ class Loupedeck(DeckWithIcons):
             image.paste(bs, (x, y))
             logger.debug(f"added {button.name} (index={button.index}) at ({x}, {y})")
         logger.debug(f"page {self.name}: ..saving..")
-        with open(page.name + ".png", "wb") as im:
+
+        # If print-page-dir is defined add this to the path
+        print_page_dir = self.get_attribute("print-page-dir")
+        if print_page_dir is None:
+            output_dst = page.name + ".png"
+        else:
+            output_dst = print_page_dir + "/" + page.name + ".png"
+
+        with open(output_dst, "wb") as im:
             image.save(im, format="PNG")
         logger.debug(f"page {self.name}: ..done")
+
 
     def render(self, button: Button):  # idx: int, image: str, label: str = None):
         if self.device is None:

--- a/cockpitdecks/decks/streamdeck.py
+++ b/cockpitdecks/decks/streamdeck.py
@@ -300,7 +300,15 @@ class Streamdeck(DeckWithIcons):
             image.paste(bs, (x, y))
             logger.debug(f"added {button.name} at ({x}, {y})")
         logger.debug(f"page {self.name}: ..saving..")
-        with open(page.name + ".png", "wb") as im:
+
+        # If print-page-dir is defined add this to the path
+        print_page_dir = self.get_attribute("print-page-dir")
+        if print_page_dir is None:
+            output_dst = page.name + ".png"
+        else:
+            output_dst = print_page_dir + "/" + page.name + ".png"
+
+        with open(output_dst, "wb") as im:
             image.save(im, format="PNG")
         logger.debug(f"page {self.name}: ..done")
 

--- a/cockpitdecks/page.py
+++ b/cockpitdecks/page.py
@@ -207,6 +207,9 @@ class Page:
         ):
             self.deck.fill_empty(key)
 
+        if self.get_attribute("print-page-dir"):
+            self.deck.print_page(self)
+
     def print(self):
         self.deck.print_page(self)
 


### PR DESCRIPTION
- page render function executes print function if print-page-dir defined in config
- loupedeck and streamdeck print functions write to file in print-page-dir

Example:
decks/lancair-evolution/deckconfig/config.yaml

Optional config parameter if defined will print on render and also take the value as the destination directory.

```
# Definition of decks for Cirrus SR22
#
aircraft: Lancair Evolution
icao: EVOT
model:  Lancair Evolution
decks:
  - name: XPLive
    type: LoupedeckLive
    layout: loupedecklive1
    brightness: 70
description: Decks for Lancair Evolution
print-page-dir: screendumps/lancair-evolution
```