### PR TITLE
Fix auto repeat for push activation

### DIFF
--- a/cockpitdecks/buttons/activation/activation.py
+++ b/cockpitdecks/buttons/activation/activation.py
@@ -553,7 +553,7 @@ class Push(Activation):
     def auto_repeat_loop(self):
         self.exit.wait(self.auto_repeat_delay)
         while not self.exit.is_set():
-            self.activate(self.pressed)
+            self.command()
             self.exit.wait(self.auto_repeat_speed)
         logger.debug(f"exited")
 


### PR DESCRIPTION
The auto_repeat_loop calls self.command() instead of self.activate(self.pressed) which caused an exception (expecting event object not bool).

Tested and looks to be working but review just in case I may have this wrong. The change is limited to the auto_repeat_loop function so should not break anything anyway. 

```
- index: 23
  type: push
  text: UP
  text-color: white
  text-size: 40
  text-font: DIN Condensed Light
  text-position: cm
  text-bg-color: black
  command: sim/autopilot/nose_up
  options: auto-repeat=1/0.05
```