### PR TITLE
Add apple-mobile-web-app-capable meta tag to deck.j2

### DIFF
--- a/bin/cockpitdecks_start.py
+++ b/bin/cockpitdecks_start.py
@@ -32,7 +32,10 @@ ac = sys.argv[1] if len(sys.argv) > 1 else None
 ac_desc = os.path.basename(ac) if ac is not None else "(no aircraft folder)"
 
 
-APP_HOST = ["192.168.1.139", 7777]
+APP_HOST = [
+    os.getenv('APP_HOST', '127.0.0.1'),
+    int(os.getenv('APP_PORT', '7777'))
+]
 
 logger.info(f"{__NAME__.title()} {__version__} {__COPYRIGHT__}")
 logger.info(f"Starting for {ac_desc}..")

--- a/cockpitdecks/decks/resources/templates/deck.j2
+++ b/cockpitdecks/decks/resources/templates/deck.j2
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Cockpitdecks - {{ deck.name }} </title>
+    <meta name="apple-mobile-web-app-capable" content="yes">
 <style type="text/css">
 body {
     width: 100%;


### PR DESCRIPTION
**Web decks**
With this tag the address bar and tabs are hidden when the deck is added to the home screen on iOS devices.

**bin/cockpitdecks_start.py**
Temporary fix to retrieve APP_HOST data from env variable so this doesn't require hard coding.

Windows:
```
set APP_HOST=10.26.1.102
set APP_PORT=7777
```
Unix/Linux/macOS:
```
export APP_HOST=10.26.1.102
export APP_PORT=7777
```
 