### PR TITLE
Bug fix: Onoff activation now remembers its state

### DIFF
--- a/cockpitdecks/buttons/activation/activation.py
+++ b/cockpitdecks/buttons/activation/activation.py
@@ -801,6 +801,7 @@ class OnOff(Activation):
                     self.command(self._commands[1])
             # Update current value and write dataref if present
             self.onoff_current_value = not self.onoff_current_value
+            self.button.set_current_value(self.onoff_current_value)  # update internal state
             self.write_dataref(self.onoff_current_value)
             self.view()
 


### PR DESCRIPTION
Small bug fix for OnOff activation.

This required two presses to work which was due to internal state not being updated.

Now when the value is updated the self.button.set_current_value is run to update internal value.

`self.button.set_current_value(self.onoff_current_value)  # update internal state`
 
Example button experiencing this issue:

```
- index: 1
  label: RECIRC
  name: RECIRC
  label-size: 10
  label-color: white
  type: onoff
  annunciator:
    size: small
    model: A
    parts:
      A0:
        text-color: white
        led: led
        formula: "${XCrafts/bleedair/recirc_switch} 0 eq"
  set-dataref: XCrafts/bleedair/recirc_switch
```